### PR TITLE
Serve Static Assets

### DIFF
--- a/lib/commands/fastboot.js
+++ b/lib/commands/fastboot.js
@@ -21,6 +21,7 @@ module.exports = {
     });
 
     var app = express();
+    app.get('/', server.middleware());
     app.use(express.static('dist'));
     app.get('/*', server.middleware());
 

--- a/lib/commands/fastboot.js
+++ b/lib/commands/fastboot.js
@@ -21,6 +21,7 @@ module.exports = {
     });
 
     var app = express();
+    app.use(express.static('dist'));
     app.get('/*', server.middleware());
 
     var ui = this.ui;

--- a/lib/models/server.js
+++ b/lib/models/server.js
@@ -1,4 +1,3 @@
-var express = require('express');
 var chalk = require('chalk');
 var fs = require('fs');
 var EmberApp = require('./ember-app');


### PR DESCRIPTION
Allow the fastboot server to serve static assets so you don't need to run a separate ember server to get your fastboot app working like in the emberconf keynote. /cc @rwjblue 