### PR TITLE
Update to ember-cli 0.2.0

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -1,8 +1,8 @@
 /* global require, module */
 
-var EmberApp = require('ember-cli/lib/broccoli/ember-app');
+var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
-var app = new EmberApp();
+var app = new EmberAddon();
 
 // Use `app.import` to add additional libraries to the generated
 // output files.

--- a/bower.json
+++ b/bower.json
@@ -1,17 +1,16 @@
 {
   "name": "ember-cli-fastboot",
   "dependencies": {
-    "handlebars": "~1.3.0",
     "jquery": "^1.11.1",
-    "ember": "1.8.1",
-    "ember-data": "1.0.0-beta.12",
-    "ember-resolver": "~0.1.11",
-    "loader.js": "ember-cli/loader.js#1.0.1",
+    "ember": "1.10.0",
+    "ember-data": "1.0.0-beta.15",
+    "ember-resolver": "~0.1.12",
+    "loader.js": "ember-cli/loader.js#3.2.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "rwjblue/ember-cli-test-loader#0.0.4",
+    "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
-    "ember-qunit": "0.1.8",
-    "ember-qunit-notifications": "0.0.4",
-    "qunit": "~1.15.0"
+    "ember-qunit": "0.2.8",
+    "ember-qunit-notifications": "0.0.7",
+    "qunit": "~1.17.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
     "test": "tests"
   },
   "repository": "https://github.com/tildeio/ember-cli-fastboot",
+  "scripts": {
+    "start": "ember server",
+    "build": "ember build",
+    "test": "ember test"
+  },
   "engines": {
     "node": ">= 0.10.0"
   },
@@ -14,16 +19,18 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
-    "broccoli-ember-hbs-template-compiler": "^1.6.1",
-    "ember-cli": "0.1.7",
+    "ember-cli": "0.2.0",
+    "ember-cli-app-version": "0.3.2",
+    "ember-cli-babel": "^4.0.0",
     "ember-cli-content-security-policy": "0.3.0",
-    "ember-cli-dependency-checker": "0.0.7",
-    "ember-cli-6to5": "0.2.1",
+    "ember-cli-dependency-checker": "0.0.8",
+    "ember-cli-htmlbars": "0.7.4",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.1.2",
-    "ember-data": "1.0.0-beta.12",
-    "ember-export-application-global": "^1.0.0"
+    "ember-cli-qunit": "0.3.9",
+    "ember-cli-uglify": "1.0.1",
+    "ember-data": "1.0.0-beta.15",
+    "ember-export-application-global": "^1.0.2"
   },
   "keywords": [
     "ember-addon"

--- a/testem.json
+++ b/testem.json
@@ -1,6 +1,6 @@
 {
   "framework": "qunit",
-  "test_page": "tests/index.html",
+  "test_page": "tests/index.html?hidepassed",
   "launch_in_ci": [
     "PhantomJS"
   ],

--- a/tests/index.html
+++ b/tests/index.html
@@ -13,22 +13,6 @@
     <link rel="stylesheet" href="assets/vendor.css">
     <link rel="stylesheet" href="assets/dummy.css">
     <link rel="stylesheet" href="assets/test-support.css">
-    <style>
-      #ember-testing-container {
-        position: absolute;
-        background: white;
-        bottom: 0;
-        right: 0;
-        width: 640px;
-        height: 384px;
-        overflow: auto;
-        z-index: 9999;
-        border: 1px solid #ccc;
-      }
-      #ember-testing {
-        zoom: 50%;
-      }
-    </style>
 
     {{content-for 'head-footer'}}
     {{content-for 'test-head-footer'}}

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -4,9 +4,3 @@ import {
 } from 'ember-qunit';
 
 setResolver(resolver);
-
-document.write('<div id="ember-testing-container"><div id="ember-testing"></div></div>');
-
-QUnit.config.urlConfig.push({ id: 'nocontainer', label: 'Hide container'});
-var containerVisibility = QUnit.urlParams.nocontainer ? 'hidden' : 'visible';
-document.getElementById('ember-testing-container').style.visibility = containerVisibility;


### PR DESCRIPTION
Updating to the latest ember-cli release. Motivated by upstream breakage in glob and/or rimraf that broke the build when I tried to install from scratch.