### PR TITLE
[WIP] Update own dummy app for fastboot compatibility

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -2,7 +2,9 @@
 
 var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
-var app = new EmberAddon();
+var app = new EmberAddon({
+  storeConfigInMeta: false
+});
 
 // Use `app.import` to add additional libraries to the generated
 // output files.

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "ember-cli-fastboot",
   "dependencies": {
     "jquery": "^1.11.1",
-    "ember": "1.10.0",
+    "ember": "canary",
     "ember-data": "1.0.0-beta.15",
     "ember-resolver": "~0.1.12",
     "loader.js": "ember-cli/loader.js#3.2.0",
@@ -11,6 +11,7 @@
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
     "ember-qunit": "0.2.8",
     "ember-qunit-notifications": "0.0.7",
-    "qunit": "~1.17.1"
+    "qunit": "~1.17.1",
+    "handlebars": "~2.0.0"
   }
 }

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -10,6 +10,8 @@ module.exports = function(environment) {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
         // e.g. 'with-controller': true
+        'ember-application-instance-initializers' : true,
+        'ember-application-visit' : true
       }
     },
 


### PR DESCRIPTION
Running `ember fastboot` inside the ember-cli-fastboot repo should boot the dummy app in fastboot mode, analogous to the way `ember serve` or `ember build` work in an addon. This would make it much easier for us to build out a test suite.

There are two remaining blockers for this behavior right now: 

 - `findAppFile` fails to discover `dummy.js` because it's looking for `ember-cli-fastboot.js` instead
 - `findHTMLFile` looks in hardcoded paths which are not correct for the dummy app.

If you hack around both of the above, it boots!

I'm not sure if ember-cli exports appropriate APIs to solve the above issues cleanly. We can certainly hack around them, but I want to get some feedback first. 