### PR TITLE
Skip unnecessary buffers

### DIFF
--- a/lib/models/ember-app.js
+++ b/lib/models/ember-app.js
@@ -23,13 +23,13 @@ function EmberApp(options) {
     najax: najax
   });
 
-  appFile = fs.readFileSync(this.appFile);
-  vendorFile = fs.readFileSync(this.vendorFile);
+  appFile = fs.readFileSync(this.appFile, 'utf8');
+  vendorFile = fs.readFileSync(this.vendorFile, 'utf8');
 
-  sandbox.run(vendorFile.toString());
+  sandbox.run(vendorFile);
   debug("vendor file evaluated");
 
-  sandbox.run(appFile.toString());
+  sandbox.run(appFile);
   debug("app file evaluated");
 
   this.waitForBoot = function() {

--- a/lib/models/server.js
+++ b/lib/models/server.js
@@ -10,8 +10,7 @@ function FastBootServer(options) {
     vendorFile: options.vendorFile
   });
 
-  this.html = fs.readFileSync(options.htmlFile);
-  this.html = this.html.toString();
+  this.html = fs.readFileSync(options.htmlFile, 'utf8');
 
   this.ui = options.ui;
 }


### PR DESCRIPTION
Minor style improvement: don't create Buffers only to convert them to Strings.

(`buffer.toString()` is already defaulting to utf8, so this is not a change in semantics.)