### PR TITLE
Enable content-for from other addons

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,5 +8,13 @@ module.exports = {
     return {
       fastboot: require('./lib/commands/fastboot')
     };
+  },
+
+  contentFor: function(type, config) {
+    // When using a dist built html file, we need to reinsert 
+    // content-for body so fastboot can insert its content.
+    if (type === 'body') {
+      return "{{content-for 'body'}}";
+    }
   }
 };

--- a/lib/commands/fastboot.js
+++ b/lib/commands/fastboot.js
@@ -75,11 +75,9 @@ function findHTMLFile() {
   var fs = require('fs');
   if (fs.existsSync('app/fastboot.html')) {
     return 'app/fastboot.html';
-  } else if (fs.existsSync('app/index.html')) {
-    return 'app/index.html';
   }
 
-  assert("Could not find either app/fastboot.html or app/index.html. Please provide an HTML file to serve FastBoot contents in.", false);
+  return findFile('html', 'dist/index*.html');
 }
 
 function findFile(name, globPath) {


### PR DESCRIPTION
Any other addons that use the contentFor hook to inject content into the html file are not respected by fastboot.  This change makes fastboot read the **built** index html.  Not sure if this is the best approach. Open to other ideas.