### PR TITLE
Use separate output path for `ember fastboot`.

### DIFF
--- a/lib/commands/fastboot.js
+++ b/lib/commands/fastboot.js
@@ -1,3 +1,5 @@
+var path = require('path');
+
 module.exports = {
   name: 'fastboot',
   description: 'Runs a server to render your app using FastBoot.',
@@ -5,18 +7,20 @@ module.exports = {
   availableOptions: [
     { name: 'build', type: Boolean, default: true },
     { name: 'environment', type: String, default: 'development', aliases: ['e',{'dev' : 'development'}, {'prod' : 'production'}] },
-    { name: 'port', type: Number, default: 3000 }
+    { name: 'port', type: Number, default: 3000 },
+    { name: 'output-path', type: String, default: 'fastboot-dist' }
   ],
 
   runCommand: function(appName, options) {
     var FastBootServer = require('../models/server');
     var RSVP = require('rsvp');
     var express = require('express');
+    var outputPath = this.commandOptions.outputPath;
 
     var server = new FastBootServer({
-      appFile: findAppFile(appName),
-      vendorFile: findVendorFile(),
-      htmlFile: findHTMLFile(),
+      appFile: findAppFile(outputPath, appName),
+      vendorFile: findVendorFile(outputPath),
+      htmlFile: findHTMLFile(outputPath),
       ui: this.ui
     });
 
@@ -44,13 +48,13 @@ module.exports = {
       project: this.project
     });
 
-    commandOptions.environment = commandOptions.environment || 'development';
-    commandOptions.outputPath = 'dist';
     return buildTask.run(commandOptions);
   },
 
   run: function(options, args) {
     process.env.EMBER_CLI_FASTBOOT = true;
+
+    this.commandOptions = options;
 
     var runCommand = function() {
       return this.runCommand(this.project.name(), options);
@@ -65,21 +69,21 @@ module.exports = {
   },
 };
 
-function findAppFile(appName) {
-  return findFile("app", "dist/assets/" + appName + "*.js");
+function findAppFile(outputPath, appName) {
+  return findFile("app", path.join(outputPath, "assets", appName + "*.js"));
 }
 
-function findVendorFile() {
-  return findFile("vendor", "dist/assets/vendor*.js");
+function findVendorFile(outputPath) {
+  return findFile("vendor", path.join(outputPath, "assets", "vendor*.js"));
 }
 
-function findHTMLFile() {
+function findHTMLFile(outputPath) {
   var fs = require('fs');
   if (fs.existsSync('app/fastboot.html')) {
     return 'app/fastboot.html';
   }
 
-  return findFile('html', 'dist/index*.html');
+  return findFile('html', path.join(outputPath, 'index*.html'));
 }
 
 function findFile(name, globPath) {


### PR DESCRIPTION
Ensures that `ember fastboot` does not clobber any running `ember server` or `ember test --server` instances running.