### PR TITLE
Add command line option for serving assets.

### DIFF
--- a/app/instance-initializers/clear-double-boot.js
+++ b/app/instance-initializers/clear-double-boot.js
@@ -1,0 +1,20 @@
+// When using `ember fastboot --serve-assets` the application output will
+// already be rendered to the DOM when the actual JavaScript loads. Ember
+// does not automatically clear its `rootElement` so this leads to the
+// "double" applications being visible at once (only the "bottom" one is
+// running via JS and is interactive).
+//
+// This removes any pre-rendered ember-view elements, so that the booting
+// application will replace the pre-rendered output
+
+export default {
+  initialize: function(instance) {
+    var originalDidCreateRootView = instance.didCreateRootView;
+
+    instance.didCreateRootView = function() {
+      Ember.$(instance.rootElement + ' .ember-view').remove();
+
+      originalDidCreateRootView.apply(instance, arguments);
+    };
+  }
+}

--- a/lib/commands/fastboot.js
+++ b/lib/commands/fastboot.js
@@ -25,6 +25,7 @@ module.exports = {
     });
 
     var app = express();
+    app.use(express.static('dist'));
     app.get('/*', server.middleware());
 
     var ui = this.ui;

--- a/lib/commands/fastboot.js
+++ b/lib/commands/fastboot.js
@@ -7,6 +7,7 @@ module.exports = {
   availableOptions: [
     { name: 'build', type: Boolean, default: true },
     { name: 'environment', type: String, default: 'development', aliases: ['e',{'dev' : 'development'}, {'prod' : 'production'}] },
+    { name: 'serve-assets', type: Boolean, default: false},
     { name: 'port', type: Number, default: 3000 },
     { name: 'output-path', type: String, default: 'fastboot-dist' }
   ],
@@ -25,8 +26,12 @@ module.exports = {
     });
 
     var app = express();
-    app.get('/', server.middleware());
-    app.use(express.static('dist'));
+
+    if (this.commandOptions.serveAssets) {
+      app.get('/', server.middleware());
+      app.use(express.static(outputPath));
+    }
+
     app.get('/*', server.middleware());
 
     var ui = this.ui;

--- a/lib/commands/fastboot.js
+++ b/lib/commands/fastboot.js
@@ -25,6 +25,7 @@ module.exports = {
     });
 
     var app = express();
+    app.get('/', server.middleware());
     app.use(express.static('dist'));
     app.get('/*', server.middleware());
 

--- a/tests/acceptance/serve-assets-test.js
+++ b/tests/acceptance/serve-assets-test.js
@@ -1,0 +1,46 @@
+var expect = require('chai').expect;
+var RSVP = require('rsvp');
+var Promise = RSVP.Promise;
+var startServer = require('../helpers/start-server');
+var delay = require('../helpers/delay');
+var request = RSVP.denodeify(require('request'));
+
+describe('serve assets acceptance', function() {
+  var server;
+
+  before(function(done) {
+    // start the server once for all tests
+    this.timeout(300000);
+
+    function grabChild(child) {
+      console.log('saving child');
+      server = child;
+      done();
+    }
+
+    return startServer(grabChild, {
+      additionalArguments: ['--serve-assets']
+    });
+  });
+
+  after(function() {
+    server.kill('SIGINT');
+
+    return delay(500);
+  });
+
+  it('/assets/vendor.js', function() {
+    return request('http://localhost:49741/assets/vendor.js')
+      .then(function(response) {
+        expect(response.body).to.contain("Ember =");
+      });
+  });
+
+  it('/assets/dummy.js', function() {
+    return request('http://localhost:49741/assets/dummy.js')
+      .then(function(response) {
+        expect(response.body).to.contain("this.route('posts')");
+      });
+  });
+});
+

--- a/tests/acceptance/simple-test.js
+++ b/tests/acceptance/simple-test.js
@@ -38,4 +38,11 @@ describe('simple acceptance', function() {
         expect(response.body).to.contain("Posts Route!");
       });
   });
+
+  it('/assets/vendor.js', function() {
+    return request('http://localhost:49741/assets/vendor.js')
+      .then(function(response) {
+        expect(response.body).not.to.contain("Ember =");
+      });
+  });
 });

--- a/tests/helpers/delay.js
+++ b/tests/helpers/delay.js
@@ -1,0 +1,8 @@
+var RSVP = require('rsvp');
+var Promise = RSVP.Promise;
+
+module.exports = function delay(ms) {
+  return new Promise(function (resolve) {
+    setTimeout(resolve, ms);
+  });
+};

--- a/tests/helpers/start-server.js
+++ b/tests/helpers/start-server.js
@@ -6,7 +6,21 @@ var path = require('path');
 var runCommand = require('ember-cli/tests/helpers/run-command');
 
 module.exports = function runServer(callback, options) {
-  options = options || { port: '49741'};
+  options = options || { };
+
+  if (!options.port) {
+    options.port = '49741';
+  }
+
+  var args = [
+    path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'),
+    'fastboot',
+    '--port', options.port
+  ];
+
+  if (options.additionalArguments) {
+    args = args.concat(options.additionalArguments);
+  }
 
   var commandOptions = {
     verbose: true,
@@ -20,9 +34,10 @@ module.exports = function runServer(callback, options) {
     }
   };
 
+  args.push(commandOptions);
+
   return new Promise(function(resolve, reject) {
-    runCommand(path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember'),
-      'fastboot', '--port', options.port, commandOptions)
+    runCommand.apply(null, args)
       .then(function() {
         throw new Error('The server should not have exited successfully.');
       })


### PR DESCRIPTION
This takes @hone's commits from #6 and supercedes it.

You can run serving assets via:

```javascript
ember fastboot --serve-assets
```

---

Please note: that pre-Glimmer Ember will not be able to start the application where the server rendered data left off.  Currently, this would mean that when the Ember app is booted in the client it will be duplicated in the DOM. To work around this, I have added an instance-initializer that clears the rootElement before initial render.