### PR TITLE
Send responses in chunks, flushing between static and dynamic sections.

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = {
     };
   },
 
-  contentFor: function(type, config) {
+  contentFor: function(type) {
     // do nothing unless running `ember fastboot` command
     if (!process.env.EMBER_CLI_FASTBOOT) { return; }
 
@@ -19,7 +19,7 @@ module.exports = {
       return "<!-- EMBER_CLI_FASTBOOT_BODY -->";
     }
 
-    if (type === 'head') {
+    if (type === 'head-footer') {
       return "<!-- EMBER_CLI_FASTBOOT_TITLE -->";
     }
 

--- a/lib/models/server.js
+++ b/lib/models/server.js
@@ -9,7 +9,7 @@ function FastBootServer(options) {
     vendorFile: options.vendorFile
   });
 
-  this.html = fs.readFileSync(options.htmlFile, 'utf8');
+  this.htmlChunks = this.getChunks(fs.readFileSync(options.htmlFile, 'utf8'));
 
   this.ui = options.ui;
 }
@@ -20,19 +20,35 @@ FastBootServer.prototype.log = function(statusCode, message) {
   this.ui.writeLine(chalk[color](statusCode) + " " + message);
 };
 
-FastBootServer.prototype.insertIntoIndexHTML = function(title, body) {
-  var html = this.html.replace("<!-- EMBER_CLI_FASTBOOT_BODY -->", body);
+FastBootServer.prototype.getChunks = function getChunks(html) {
+  return html.split(/<!-- (EMBER_CLI_FASTBOOT_\w+) -->/g);
+};
 
-  if (title) {
-    html = html.replace("<!-- EMBER_CLI_FASTBOOT_TITLE -->", "<title>" + title + "</title>");
+FastBootServer.prototype.getChunk = function getChunk(type, result) {
+  var resultProp = type.slice(19).toLowerCase();
+  var output;
+
+  if (result.title && resultProp === 'title') {
+    output = "<title>" + result.title + "</title>";
+  } else {
+    output = result[resultProp] || type;
   }
 
-  return html;
+  return output;
 };
 
 FastBootServer.prototype.handleSuccess = function(res, path, result) {
   this.log(200, 'OK ' + path);
-  res.send(this.insertIntoIndexHTML(result.title, result.body));
+  res.type('html');
+  res.status(200);
+
+  var chunks = this.htmlChunks;
+  for (var i = 0, l = chunks.length; i < l; i++) {
+    var chunk = this.getChunk(chunks[i], result);
+
+    res.write(chunk);
+  }
+  res.end();
 };
 
 FastBootServer.prototype.handleFailure = function(res, path, error) {

--- a/tests/acceptance/serve-assets-test.js
+++ b/tests/acceptance/serve-assets-test.js
@@ -12,7 +12,6 @@ describe('serve assets acceptance', function() {
     this.timeout(300000);
 
     function grabChild(child) {
-      console.log('saving child');
       server = child;
       done();
     }
@@ -46,4 +45,3 @@ describe('serve assets acceptance', function() {
       });
   });
 });
-

--- a/tests/acceptance/simple-test.js
+++ b/tests/acceptance/simple-test.js
@@ -11,7 +11,6 @@ describe('simple acceptance', function() {
     this.timeout(300000);
 
     function grabChild(child) {
-      console.log('saving child');
       server = child;
       done();
     }


### PR DESCRIPTION
This should allow the bulk of the `<head>` content to be sent before the Ember app is booted and rendered in fastboot.  Thus allowing the client browser to start fetching assets and whatnot.

A similar technique is done in various other frameworks (including Rails).