### PR TITLE
Actually return 404 status code

### DIFF
--- a/lib/models/server.js
+++ b/lib/models/server.js
@@ -39,7 +39,7 @@ FastBootServer.prototype.handleSuccess = function(res, path, result) {
 FastBootServer.prototype.handleFailure = function(res, path, error) {
   if (error.name === "UnrecognizedURLError") {
     this.log(404, "Not Found " + path);
-    res.sendStatus(400);
+    res.sendStatus(404);
   } else {
     console.log(error.stack);
     this.log(500, "Unknown Error: " + error);


### PR DESCRIPTION
Fixes #31, since no one claimed it yet :stuck_out_tongue: 

As far as I can tell this is just a typo (introduced in 3c0a499), there doesn't seem to be a real reason to return 400 instead of 404.