### PR TITLE
Fix clear-double-boot with virtual application view

### DIFF
--- a/app/instance-initializers/clear-double-boot.js
+++ b/app/instance-initializers/clear-double-boot.js
@@ -12,7 +12,7 @@ export default {
     var originalDidCreateRootView = instance.didCreateRootView;
 
     instance.didCreateRootView = function() {
-      Ember.$(instance.rootElement + ' .ember-view').remove();
+      Ember.$(instance.rootElement).children().not('script').remove();
 
       originalDidCreateRootView.apply(instance, arguments);
     };


### PR DESCRIPTION
The temporary [initializer](https://github.com/tildeio/ember-cli-fastboot/commit/1a71c5f2843b81bb8875abb54a9561dac27a6f94) to remove the double-rendered app when fastbooting with `--serve-assets` was not working when the application view is virtual.