### PR TITLE
Include the --serve-assets flag in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ unsure of. Make sure you pick ember#canary if prompted.
 
 ## Running
 
-* `ember fastboot`
+* `ember fastboot --serve-assets`
 * Visit your app at `http://localhost:3000`.
 
 You may be shocked to learn that minified code runs faster in Node than


### PR DESCRIPTION
This tripped me up the first few times I tried to work with FastBoot. I propose it be included in the README, be set as a default, or we leave a note as to why neither of the first two options were taken.