### PR TITLE
Add self property to sandbox for global detection

### DIFF
--- a/lib/models/ember-app.js
+++ b/lib/models/ember-app.js
@@ -79,6 +79,7 @@ function createSandbox(appBootResolver, dependencies) {
 
   // Set the global as `window`.
   sandbox.window = sandbox;
+  sandbox.window.self = sandbox;
 
   // The sandbox is now a JavaScript context O_o
   Contextify(sandbox);


### PR DESCRIPTION
Fixes #47 by adding a self property to the sandbox. The issue is due to a change in the way Backburner assigns and detects the global object introduced in [this commit](https://github.com/ebryn/backburner.js/commit/f20af9e053a0214357743ffaecd0040a65151960).