### PR TITLE
Implement naive meta tag support

### DIFF
--- a/app/initializers/fastboot.js
+++ b/app/initializers/fastboot.js
@@ -36,6 +36,7 @@ export default {
         return App.visit(url).then(function(instance) {
           var view = instance.view;
           var title = view.renderer._dom.document.title;
+          var metaTags = view.renderer.metaTags;
           var element;
 
           Ember.run(function() {
@@ -48,7 +49,8 @@ export default {
 
           return {
             body: serializer.serialize(element),
-            title: title
+            title: title,
+            metaTags: metaTags,
           };
         });
       });

--- a/index.js
+++ b/index.js
@@ -15,12 +15,12 @@ module.exports = {
     // do nothing unless running `ember fastboot` command
     if (!process.env.EMBER_CLI_FASTBOOT) { return; }
 
-    if (type === 'body') {
-      return "<!-- EMBER_CLI_FASTBOOT_BODY -->";
-    }
-
     if (type === 'head') {
       return "<!-- EMBER_CLI_FASTBOOT_HEAD -->";
+    }
+
+    if (type === 'body') {
+      return "<!-- EMBER_CLI_FASTBOOT_BODY -->";
     }
 
     if (type === 'vendor-prefix') {

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = {
     }
 
     if (type === 'head') {
-      return "<!-- EMBER_CLI_FASTBOOT_TITLE -->";
+      return "<!-- EMBER_CLI_FASTBOOT_HEAD -->";
     }
 
     if (type === 'vendor-prefix') {

--- a/lib/models/server.js
+++ b/lib/models/server.js
@@ -20,35 +20,21 @@ FastBootServer.prototype.log = function(statusCode, message) {
   this.ui.writeLine(chalk[color](statusCode) + " " + message);
 };
 
-FastBootServer.prototype.insertIntoIndexHTML = function(title, body, metaTags) {
-  var html = this.html.replace("<!-- EMBER_CLI_FASTBOOT_BODY -->", body);
+FastBootServer.prototype.insertIntoIndexHTML = function(result) {
+  var html = this.html;
 
-  var head = "";
+  html = html.replace("<!-- EMBER_CLI_FASTBOOT_BODY -->", result.body);
 
-  if (title) {
-    head += "<title>" + title + "</title>\n";
+  if (result.head) {
+    html = html.replace("<!-- EMBER_CLI_FASTBOOT_HEAD -->", result.head);
   }
-
-  if (metaTags) {
-    metaTags.forEach(function(metaTag) {
-      var properties = '';
-
-      Object.keys(metaTag).forEach(function(key) {
-        properties += key + '="' + metaTag[key] + '" ';
-      });
-
-      head += '<meta ' + properties.trim() + '>\n';
-    });
-  }
-
-  html = html.replace("<!-- EMBER_CLI_FASTBOOT_HEAD -->", head);
 
   return html;
 };
 
 FastBootServer.prototype.handleSuccess = function(res, path, result) {
   this.log(200, 'OK ' + path);
-  res.send(this.insertIntoIndexHTML(result.title, result.body, result.metaTags));
+  res.send(this.insertIntoIndexHTML(result));
 };
 
 FastBootServer.prototype.handleFailure = function(res, path, error) {

--- a/lib/models/server.js
+++ b/lib/models/server.js
@@ -20,19 +20,35 @@ FastBootServer.prototype.log = function(statusCode, message) {
   this.ui.writeLine(chalk[color](statusCode) + " " + message);
 };
 
-FastBootServer.prototype.insertIntoIndexHTML = function(title, body) {
+FastBootServer.prototype.insertIntoIndexHTML = function(title, body, metaTags) {
   var html = this.html.replace("<!-- EMBER_CLI_FASTBOOT_BODY -->", body);
 
+  var head = "";
+
   if (title) {
-    html = html.replace("<!-- EMBER_CLI_FASTBOOT_TITLE -->", "<title>" + title + "</title>");
+    head += "<title>" + title + "</title>\n";
   }
+
+  if (metaTags) {
+    metaTags.forEach(function(metaTag) {
+      var properties = '';
+
+      Object.keys(metaTag).forEach(function(key) {
+        properties += key + '="' + metaTag[key] + '" ';
+      });
+
+      head += '<meta ' + properties.trim() + '>\n';
+    });
+  }
+
+  html = html.replace("<!-- EMBER_CLI_FASTBOOT_HEAD -->", head);
 
   return html;
 };
 
 FastBootServer.prototype.handleSuccess = function(res, path, result) {
   this.log(200, 'OK ' + path);
-  res.send(this.insertIntoIndexHTML(result.title, result.body));
+  res.send(this.insertIntoIndexHTML(result.title, result.body, result.metaTags));
 };
 
 FastBootServer.prototype.handleFailure = function(res, path, error) {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "contextify": "^0.1.11",
     "najax": "^0.1.5",
     "rsvp": "^3.0.16",
-    "simple-dom": "0.2.3",
+    "simple-dom": "0.2.7",
     "chalk": "^0.5.1",
     "express": "^4.8.5",
     "glob": "^4.0.5",

--- a/tests/acceptance/simple-test.js
+++ b/tests/acceptance/simple-test.js
@@ -29,6 +29,8 @@ describe('simple acceptance', function() {
         expect(response.statusCode).to.equal(200);
         expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
         expect(response.body).to.contain('<title>Application Route -- Title</title>');
+        expect(response.body).to.contain('<meta name="description" content="something here">');
+        expect(response.body).to.contain('<meta property="og:image" content="http://placehold.it/500x500">');
         expect(response.body).to.contain("Welcome to Ember.js");
       });
   });
@@ -39,6 +41,8 @@ describe('simple acceptance', function() {
         expect(response.statusCode).to.equal(200);
         expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
         expect(response.body).to.contain('<title>Application Route -- Title</title>');
+        expect(response.body).to.contain('<meta name="description" content="something here">');
+        expect(response.body).to.contain('<meta property="og:image" content="http://placehold.it/500x500">');
         expect(response.body).to.contain("Welcome to Ember.js");
         expect(response.body).to.contain("Posts Route!");
       });

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>Dummy</title>
-    <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {{content-for 'head'}}

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -5,6 +5,13 @@ export default Ember.Route.extend({
     didTransition: function() {
       var renderer = this.container.lookup('renderer:-dom');
       Ember.set(renderer, '_dom.document.title', 'Application Route -- Title');
+      Ember.set(renderer, 'metaTags', [{
+        name: 'description',
+        content: 'something here'
+      }, {
+        property: 'og:image',
+        content: 'http://placehold.it/500x500'
+      }]);
     }
   }
 });

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -6,12 +6,20 @@ export default Ember.Route.extend({
       var renderer = this.container.lookup('renderer:-dom');
       Ember.set(renderer, '_dom.document.title', 'Application Route -- Title');
       Ember.set(renderer, 'metaTags', [{
-        name: 'description',
-        content: 'something here'
-      }, {
-        property: 'og:image',
-        content: 'http://placehold.it/500x500'
-      }]);
+          name: 'meta',
+          attrs: {
+            name: 'description',
+            content: 'something here'
+          }
+        },
+        {
+          name: 'meta',
+          attrs: {
+            property: 'og:image',
+            content: 'http://placehold.it/500x500'
+          }
+        }
+      ]);
     }
   }
 });


### PR DESCRIPTION
After hearing about Dockyard's new site using fastboot, we wanted to take it out for a spin on a new project. We noticed it wasn't yet possible to set meta tags like `description`. This allows setting meta tags similar to how we can set the document's title.

```javascript
Ember.set(renderer, '_dom.document.title', 'Application Route -- Title');
Ember.set(renderer, 'metaTags', [{
  name: 'description',
  content: 'something here'
}, {
  property: 'og:image',
  content: 'http://placehold.it/500x500'
}]);
```

This obviously still feels hacky but seems to work just fine so we decided to share and hopefully get some feedback.

Update: With a few simple tweaks this and #23 can play nicely together.