### PR TITLE
Use `Ember._Renderer` if present.

### DIFF
--- a/app/initializers/fastboot.js
+++ b/app/initializers/fastboot.js
@@ -23,7 +23,8 @@ export default {
       // so it would be nice if we could register just that.
       registry.register('renderer:-dom', {
         create: function() {
-          return new Ember.View._Renderer(domHelper, false);
+          var Renderer = Ember._Renderer || Ember.View._Renderer;
+          return new Renderer(domHelper, false);
         }
       });
 


### PR DESCRIPTION
`Ember.View` will no longer be exported in Ember 2.0.0, the former `Ember.View._Renderer` was moved to `Ember._Renderer`.

The upstream change is made in https://github.com/emberjs/ember.js/pull/11794.