### PR TITLE
Fix display of ipv6 fastboot server uri

### DIFF
--- a/lib/commands/fastboot.js
+++ b/lib/commands/fastboot.js
@@ -39,6 +39,9 @@ module.exports = {
     var listener = app.listen(options.port, function() {
       var host = listener.address().address;
       var port = listener.address().port;
+      var family = listener.address().family;
+
+      if (family === 'IPv6') { host = '[' + host + ']'; }
 
       ui.writeLine('Ember FastBoot running at http://' + host + ":" + port);
     });


### PR DESCRIPTION
IPv6 addresses must be enclosed in square brackets when used inside URIs to avoid ambiguity when parsing the port (see RFC 3986 section 3.2.2).

This addresses the URI display issue discussed in #46.