### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In order to get FastBoot working, you will first need to enable Ember Canary:
 
 ```
 rm -rf bower_components
-bower install --save ember#canary
+bower install --save ember#canary ember-data#canary
 bower install
 ```
 


### PR DESCRIPTION
Both ember and ember-data needs to point to the canary branch since ember v2.x.x is incompatible with ember-data v1.x.x