### PR TITLE
Better failure detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,12 +42,11 @@ module.exports = {
     if (process.env.EMBER_CLI_FASTBOOT) {
       process.env.EMBER_CLI_FASTBOOT_APP_NAME = app.name;
       app.options.autoRun = false;
+      patchEmberApp(app);
     }
 
     // We serve the index.html from fastboot-dist, so this has to apply to both builds
     app.options.storeConfigInMeta = false;
-
-    patchEmberApp(app);
   },
 
   config: function(/* environment, appConfig */) {

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var Funnel = require('broccoli-funnel');
+var patchEmberApp = require('./lib/ext/patch-ember-app');
 
 // Expose the an factory for the creating the `Application` object
 // with the proper config at a known path, so that the server does
@@ -45,6 +46,8 @@ module.exports = {
 
     // We serve the index.html from fastboot-dist, so this has to apply to both builds
     app.options.storeConfigInMeta = false;
+
+    patchEmberApp(app);
   },
 
   config: function(/* environment, appConfig */) {

--- a/lib/ext/patch-ember-app.js
+++ b/lib/ext/patch-ember-app.js
@@ -1,7 +1,6 @@
 var log = require('broccoli-stew').log;
 var debug = require('broccoli-stew').debug;
 var map = require('broccoli-stew').map;
-var vm = require('vm');
 
 function patchEmberApp(emberApp) {
   var originalConcatFiles = emberApp.concatFiles;
@@ -17,19 +16,6 @@ function patchEmberApp(emberApp) {
 
 function wrap(content, path) {
   path = escape(path);
-
-  var validJS = true;
-
-  // Detect if someone put invalid JavaScript in a .js file
-  try {
-    vm.runInNewContext(content);
-  } catch(e) {
-    if (e instanceof SyntaxError) {
-      validJS = false;
-    }
-  }
-
-  if (!validJS) { return content; }
 
   return "\ntry {\n" +
         content +

--- a/lib/ext/patch-ember-app.js
+++ b/lib/ext/patch-ember-app.js
@@ -1,0 +1,44 @@
+var log = require('broccoli-stew').log;
+var debug = require('broccoli-stew').debug;
+var map = require('broccoli-stew').map;
+var vm = require('vm');
+
+function patchEmberApp(emberApp) {
+  var originalConcatFiles = emberApp.concatFiles;
+
+  emberApp.concatFiles = function(tree, options) {
+    if (options.annotation === 'Concat: Vendor') {
+      tree = map(tree, '**/*.js', wrap);
+    }
+
+    return originalConcatFiles.call(this, tree, options);
+  };
+}
+
+function wrap(content, path) {
+  path = escape(path);
+
+  var validJS = true;
+
+  // Detect if someone put invalid JavaScript in a .js file
+  try {
+    vm.runInNewContext(content);
+  } catch(e) {
+    if (e instanceof SyntaxError) {
+      validJS = false;
+    }
+  }
+
+  if (!validJS) { return content; }
+
+  return "\ntry {\n" +
+        content +
+    "\n} catch (error) { \n " +
+    " console.log(error, 'Error evaluating " + path + "');\n}\n";
+}
+
+function escape(path) {
+  return path.replace(/'/, "\\'");
+}
+
+module.exports = patchEmberApp;

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "broccoli-funnel": "0.2.8",
+    "broccoli-stew": "^1.0.4",
     "chalk": "^0.5.1",
     "contextify": "^0.1.11",
     "debug": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "configPath": "tests/dummy/config"
   },
   "dependencies": {
-    "broccoli-funnel": "0.2.8",
+    "broccoli-funnel": "^1.0.1",
     "broccoli-stew": "^1.0.4",
     "chalk": "^0.5.1",
     "contextify": "^0.1.11",


### PR DESCRIPTION
This commit wraps each file that gets put in `vendor` in a `try/catch`. This allows us to capture FastBoot-incompatible addons and print a much more useful error message in the console.

Note that this relies on monkeypatching Ember CLI's `EmberApp` method in a very hacky way. @stefanpenner thinks it may be appropriate to expose a hook that we can use instead.