### PR TITLE
Enable `storeConfigInMeta` only for FastBoot builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,10 +41,10 @@ module.exports = {
     if (process.env.EMBER_CLI_FASTBOOT) {
       process.env.EMBER_CLI_FASTBOOT_APP_NAME = app.name;
       app.options.autoRun = false;
+      
+      // We serve the index.html from fastboot-dist, so this has to apply to both builds
+      app.options.storeConfigInMeta = false;
     }
-
-    // We serve the index.html from fastboot-dist, so this has to apply to both builds
-    app.options.storeConfigInMeta = false;
   },
 
   config: function(/* environment, appConfig */) {


### PR DESCRIPTION
Fixes #80 