### PR TITLE
Add fastboot-config with whitelisted modules

### DIFF
--- a/lib/utilities/fastboot-app-module.js
+++ b/lib/utilities/fastboot-app-module.js
@@ -1,0 +1,25 @@
+// Expose the an factory for the creating the `Application` object
+// with the proper config at a known path, so that the server does
+// not have to disover the app's module prefix ("my-app").
+//
+// The module defined here is prefixed with a `~` to make it less
+// likely to collide with user code, since it is not possible to
+// define a module with a name like this in the file system.
+function fastbootAppModule(prefix) {
+  return [
+    "",
+    "define('~fastboot/app-factory', ['{{MODULE_PREFIX}}/app', '{{MODULE_PREFIX}}/config/environment'], function(App, config) {",
+    "  App = App['default'];",
+    "  config = config['default'];",
+    "",
+    "  return {",
+    "    'default': function() {",
+    "      return App.create(config.APP);",
+    "    }",
+    "  };",
+    "});",
+    ""
+  ].join("\n").replace(/\{\{MODULE_PREFIX\}\}/g, prefix);
+}
+
+module.exports = fastbootAppModule;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
     "chai": "^2.2.0",
-    "cpr": "^0.4.2",
+    "chai-fs": "peterkc/chai-fs#31deec5232297e2887a2ffb39b9081364c8e78e1",
+    "cpr": "^1.0.0",
     "ember-cli": "1.13.8",
     "ember-cli-app-version": "0.5.0",
     "ember-cli-content-security-policy": "0.4.0",
@@ -52,14 +53,16 @@
     "configPath": "tests/dummy/config"
   },
   "dependencies": {
+    "broccoli-file-creator": "^1.1.0",
     "broccoli-funnel": "0.2.8",
+    "broccoli-merge-trees": "^1.1.1",
     "chalk": "^0.5.1",
     "contextify": "^0.1.11",
     "debug": "^2.1.0",
     "ember-fastboot-server": "0.1.0",
     "express": "^4.8.5",
     "glob": "^4.0.5",
-    "najax": "^0.1.5",
+    "lodash.uniq": "^4.0.1",
     "rsvp": "^3.0.16",
     "silent-error": "^1.0.0"
   }

--- a/tests/acceptance/module-whitelist-test.js
+++ b/tests/acceptance/module-whitelist-test.js
@@ -1,0 +1,90 @@
+var chai             = require('chai');
+var expect           = chai.expect;
+var path             = require('path');
+var fs               = require('fs');
+var runCommand       = require('ember-cli/tests/helpers/run-command');
+var emberCommand     = path.join('.', 'node_modules', 'ember-cli', 'bin', 'ember');
+
+var acceptance       = require('../helpers/acceptance');
+var createApp        = acceptance.createApp;
+var copyFixtureFiles = acceptance.copyFixtureFiles;
+
+chai.use(require('chai-fs'));
+
+var appName = 'module-whitelist';
+
+describe('module-whitelist', function() {
+  this.timeout(300000);
+
+  describe('FastBoot builds', function() {
+
+    before(function() {
+      return createApp(appName)
+        .then(function() {
+          return copyFixtureFiles(appName);
+        })
+        .then(addFastBootDeps)
+        .then(buildApp(true))
+        .catch(function(e) {
+          console.log(e.stack);
+        });
+    });
+
+    it('builds a fastboot-config.json', function() {
+      expect('fastboot-dist/fastboot-config.json').to.be.a.file();
+    });
+
+    it("merges FastBoot dependencies from multiple addons", function() {
+      var config = fs.readFileSync('fastboot-dist/fastboot-config.json');
+      config = JSON.parse(config);
+
+      expect(config.moduleWhitelist).to.deep.equal(['foo', 'bar', 'baz']);
+    });
+
+  });
+
+  describe('non-FastBoot builds', function() {
+    before(function() {
+      return createApp(appName)
+        .then(function() {
+          return copyFixtureFiles(appName);
+        })
+        .then(addFastBootDeps)
+        .then(buildApp())
+        .catch(function(e) {
+          console.log(e.stack);
+        });
+    });
+
+    it('does not include a fastboot-config.json', function() {
+      expect(fs.existsSync('fastboot-dist/fastboot-config')).to.equal(false);
+    });
+  });
+
+});
+
+function addFastBootDeps() {
+  var pkg = JSON.parse(fs.readFileSync('package.json'));
+  pkg['devDependencies']['fake-addon'] = "*";
+  pkg['devDependencies']['fake-addon-2'] = "*";
+  fs.writeFileSync('package.json', JSON.stringify(pkg));
+}
+
+function buildApp(fastBoot) {
+  return function() {
+    var args = [
+      emberCommand,
+      fastBoot ? 'fastboot:build' : 'build'
+    ];
+
+    var commandOptions = {
+      verbose: true,
+
+      onOutput: function() { }
+    };
+
+    args.push(commandOptions);
+
+    return runCommand.apply(null, args);
+  };
+}

--- a/tests/acceptance/simple-test.js
+++ b/tests/acceptance/simple-test.js
@@ -29,7 +29,6 @@ describe('simple acceptance', function() {
         return startServer(grabChild);
       })
       .catch(function(e) {
-        console.log(e);
         console.log(e.stack);
       });
   });

--- a/tests/fixtures/module-whitelist/README.md
+++ b/tests/fixtures/module-whitelist/README.md
@@ -1,0 +1,2 @@
+This fixture app has two addons in its `node_module` directory that have
+FastBoot deps.

--- a/tests/fixtures/module-whitelist/node_modules/fake-addon-2/index.js
+++ b/tests/fixtures/module-whitelist/node_modules/fake-addon-2/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  name: "Fake Addon"
+};

--- a/tests/fixtures/module-whitelist/node_modules/fake-addon-2/package.json
+++ b/tests/fixtures/module-whitelist/node_modules/fake-addon-2/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "fake-addon-2",
+  "version": "0.1.0",
+  "ember-addon": {
+    "fastBootDependencies": ["bar", "baz"]
+  },
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/tests/fixtures/module-whitelist/node_modules/fake-addon/index.js
+++ b/tests/fixtures/module-whitelist/node_modules/fake-addon/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  name: "Fake Addon"
+};

--- a/tests/fixtures/module-whitelist/node_modules/fake-addon/package.json
+++ b/tests/fixtures/module-whitelist/node_modules/fake-addon/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "fake-addon",
+  "version": "0.1.0",
+  "ember-addon": {
+    "fastBootDependencies": ["foo", "bar"]
+  },
+  "keywords": [
+    "ember-addon"
+  ]
+}


### PR DESCRIPTION
This commit adds generation of a `fastboot-config.json` to the `fastboot-dist`. For now, this only includes one field which is a list of npm packages that are needed when the app is running in FastBoot.

For example, a `fastboot-config.json` may look like this:

```json
{
  "moduleWhitelist": ["najax", "node-fetch"]
}
```

The list of whitelisted modules is derived from the app's installed addons. Addons can add a `fastBootDependencies` key to their `package.json`'s `ember-addon` field:

```json
{
  "name": "ember-network",
  "version": "0.1.0",
  "ember-addon": {
    "fastBootDependencies": ["node-fetch"]
  }
}
```

Each addon's list of dependencies will be aggregated and placed into a single list of whitelisted modules.