### PR TITLE
Allow to define host as parameter, and set the default as [::]

### DIFF
--- a/lib/commands/fastboot.js
+++ b/lib/commands/fastboot.js
@@ -8,6 +8,7 @@ module.exports = {
     { name: 'build', type: Boolean, default: true },
     { name: 'environment', type: String, default: 'development', aliases: ['e',{'dev' : 'development'}, {'prod' : 'production'}] },
     { name: 'serve-assets', type: Boolean, default: false },
+    { name: 'host', type: String, default: '::' },
     { name: 'port', type: Number, default: 3000 },
     { name: 'output-path', type: String, default: 'fastboot-dist' },
     { name: 'assets-path', type: String, default: 'dist' }
@@ -39,7 +40,7 @@ module.exports = {
 
     var ui = this.ui;
 
-    var listener = app.listen(options.port, function() {
+    var listener = app.listen(options.port, options.host, function() {
       var host = listener.address().address;
       var port = listener.address().port;
       var family = listener.address().family;


### PR DESCRIPTION
So know you can `ember fastboot --host 0.0.0.0`

solve #92 