### PR TITLE
Replace ajax{Success,Error} with an override of `adapter._ajaxRequest`

### DIFF
--- a/app/initializers/server/ajax.js
+++ b/app/initializers/server/ajax.js
@@ -1,21 +1,7 @@
-/*globals najax, Ember*/
-var nodeAjax = function(url, type, options) {
-  var adapter = this;
+/* globals najax */
 
-  return new Ember.RSVP.Promise(function(resolve, reject) {
-    var hash = adapter.ajaxOptions(url, type, options);
-
-    hash.success = function(json, textStatus, jqXHR) {
-      json = adapter.ajaxSuccess(jqXHR, json);
-      Ember.run(null, resolve, json);
-    };
-
-    hash.error = function(jqXHR, textStatus, errorThrown) {
-      Ember.run(null, reject, adapter.ajaxError(jqXHR, jqXHR.responseText, errorThrown));
-    };
-
-    najax(hash);
-  }, 'DS: RESTAdapter#ajax ' + type + ' to ' + url);
+var nodeAjax = function(options) {
+  najax(options);
 };
 
 export default {
@@ -23,6 +9,6 @@ export default {
 
   initialize: function(application) {
     application.register('ajax:node', nodeAjax, { instantiate: false });
-    application.inject('adapter', 'ajax', 'ajax:node');
+    application.inject('adapter', '_ajaxRequest', 'ajax:node');
   }
 };


### PR DESCRIPTION
Per @tchak's suggestion, moving the jQuery request in the Ember Data
adapter [here][ed-pr], the code to replace `jQuery.ajax` with `najax`
becomes trivial, and replaces all code duplication.

There was an update to najax that is needed for Ember data to be able to
parse the headers. That code is available on the master branch of najax,
but has not been released.

This also depends on the latest beta branch of Ember Data, and will be
compatible with ED 2.4

[ed-pr]: emberjs/data#4113