### PR TITLE
Add prepend information to `fastboot-dist/package.json`

### DIFF
--- a/lib/addon-modes/fastboot.js
+++ b/lib/addon-modes/fastboot.js
@@ -72,11 +72,17 @@ module.exports = {
   //
 
   treeForFastBootConfig: function() {
-    var config = new FastBootConfig({
+    var optionsForConfig = {
       project: this.project,
       outputPaths: this.outputPaths,
       ui: this.ui
-    });
+    };
+
+    if (this.app.options.fingerprint && this.app.options.fingerprint.prepend) {
+      optionsForConfig.assetPrepend = this.app.options.fingerprint.prepend;
+    }
+
+    var config = new FastBootConfig(optionsForConfig);
     return writeFile('package.json', config.toJSONString());
   }
 

--- a/lib/models/fastboot-config.js
+++ b/lib/models/fastboot-config.js
@@ -6,6 +6,7 @@ function FastBootConfig(options) {
   this.project = options.project;
   this.ui = options.ui;
   this.outputPaths = options.outputPaths;
+  this.assetPrepend = options.assetPrepend;
 
   this.buildDependencies();
   this.buildManifest();
@@ -50,6 +51,10 @@ FastBootConfig.prototype.buildManifest = function() {
     htmlFile: strip(outputPaths.app.html),
     vendorFile: strip(outputPaths.vendor.js)
   };
+
+  if (this.assetPrepend) {
+    this.manifest.assetPrepend = this.assetPrepend;
+  }
 };
 
 FastBootConfig.prototype.toJSONString = function() {


### PR DESCRIPTION
Grabs the prepend option set when fingerprinting the files and appends it to the package.json file so that `ember-fastboot-server` can remove the prepend details. Used by the changes added [here](https://github.com/ember-fastboot/ember-fastboot-server/pull/11)

This PR plus https://github.com/ember-fastboot/ember-fastboot-server/pull/11 closes #102

For asset-rev to manage the `fastboot-dist/package.json`, `'json'` must be added to the `replaceExtensions` setting in brocolli-asset-rev