### PR TITLE
Tests for environment-specific initializers

### DIFF
--- a/lib/addon-modes/browser.js
+++ b/lib/addon-modes/browser.js
@@ -1,10 +1,11 @@
 var filterInitializers = require('../broccoli/filter-initializers');
+
 module.exports = {
   /**
    * Filters out initializers and instance initializers that should only run in
    * FastBoot mode.
    */
-  treeForApp: function(tree) {
-    return filterInitializers(tree, 'server');
+  preconcatTree: function(tree) {
+    return filterInitializers(tree, 'fastboot', this.app.name);
   }
 };

--- a/lib/addon-modes/fastboot.js
+++ b/lib/addon-modes/fastboot.js
@@ -1,4 +1,3 @@
-var path       = require('path');
 var mergeTrees = require('broccoli-merge-trees');
 var Funnel     = require('broccoli-funnel');
 
@@ -36,14 +35,12 @@ module.exports = {
     return CONFIG;
   },
 
+  /**
+   * Filters out initializers and instance initializers that should only run in
+   * browser mode.
+   */
   preconcatTree: function(tree) {
-    return new Funnel(tree, {
-      annotation: 'Funnel: Remove browser-only initializers',
-      exclude: [
-        path.join(this.app.name, 'initializers/browser/*'),
-        path.join(this.app.name, 'instance-initializers/browser/*')
-      ]
-    });
+    return filterInitializers(tree, 'browser', this.app.name);
   },
 
   /**
@@ -66,14 +63,6 @@ module.exports = {
     }
 
     return tree;
-  },
-
-  /**
-   * Filters out initializers and instance initializers that should only run in
-   * browser mode.
-   */
-  treeForApp: function(tree) {
-    return filterInitializers(tree, 'browser');
   },
 
   /**

--- a/lib/broccoli/filter-initializers.js
+++ b/lib/broccoli/filter-initializers.js
@@ -1,11 +1,12 @@
 var Funnel = require('broccoli-funnel');
+var path   = require('path');
 
-module.exports = function(tree, mode) {
+module.exports = function(tree, mode, appPath) {
   return new Funnel(tree, {
     annotation: 'Funnel: Remove ' + mode + '-only initializers',
     exclude: [
-      'initializers/' + mode + '/*',
-      'instance-initializers/' + mode + '/*'
+      path.join(appPath, 'initializers/' + mode + '/*'),
+      path.join(appPath, 'instance-initializers/' + mode + '/*')
     ]
   });
 };

--- a/tests/acceptance/dynamic-initializers-test.js
+++ b/tests/acceptance/dynamic-initializers-test.js
@@ -1,0 +1,58 @@
+var chai = require('chai');
+var expect = chai.expect;
+chai.use(require('chai-fs'));
+
+var AddonTestApp     = require('ember-cli-addon-tests').AddonTestApp;
+
+describe('dynamic initializers', function() {
+  this.timeout(300000);
+
+  var app;
+
+  before(function() {
+
+    app = new AddonTestApp();
+
+    return app.create('dynamic-initializers');
+  });
+
+  it("filters FastBoot initializers from browser build", function() {
+    return app.runEmberCommand('build')
+      .then(function() {
+        var appPath = app.filePath('dist/assets/dynamic-initializers.js');
+        expect(appPath).to.not.have.content.that.match(
+          /But I warn you, if you don't tell me that this means war/);
+        expect(appPath).to.have.content.that.match(
+          /Well, Prince, so Genoa and Lucca are now just family estates/);
+      });
+  });
+
+  it("filters browser initializers from FastBoot build", function() {
+    return app.runEmberCommand('fastboot:build')
+      .then(function() {
+        var appPath = app.filePath('fastboot-dist/assets/dynamic-initializers.js');
+        expect(appPath).to.have.content.that.match(
+          /But I warn you, if you don't tell me that this means war/);
+        expect(appPath).to.not.have.content.that.match(
+          /Well, Prince, so Genoa and Lucca are now just family estates/);
+      });
+  });
+
+  it("filters FastBoot instance initializers from browser build", function() {
+    return app.runEmberCommand('build')
+      .then(function() {
+        var appPath = app.filePath('dist/assets/dynamic-initializers.js');
+        expect(appPath).to.not.have.content.that.match(/It was in July, 1805/);
+        expect(appPath).to.have.content.that.match(/But how do you do/);
+      });
+  });
+
+  it("filters browser instance initializers from FastBoot build", function() {
+    return app.runEmberCommand('fastboot:build')
+      .then(function() {
+        var appPath = app.filePath('fastboot-dist/assets/dynamic-initializers.js');
+        expect(appPath).to.have.content.that.match(/It was in July, 1805/);
+        expect(appPath).to.not.have.content.that.match(/But how do you do/);
+      });
+  });
+});

--- a/tests/fixtures/dynamic-initializers/app/initializers/browser/initializer.js
+++ b/tests/fixtures/dynamic-initializers/app/initializers/browser/initializer.js
@@ -1,0 +1,2 @@
+export default `Well, Prince, so Genoa and Lucca are now just family estates of the
+Buonapartes.`;

--- a/tests/fixtures/dynamic-initializers/app/initializers/fastboot/initializer.js
+++ b/tests/fixtures/dynamic-initializers/app/initializers/fastboot/initializer.js
@@ -1,0 +1,5 @@
+export default `But I warn you, if you don't tell me that this means war,
+if you still try to defend the infamies and horrors perpetrated by that
+Antichrist--I really believe he is Antichrist--I will have nothing more
+to do with you and you are no longer my friend, no longer my 'faithful
+slave,' as you call yourself!`;

--- a/tests/fixtures/dynamic-initializers/app/instance-initializers/browser/initializer.js
+++ b/tests/fixtures/dynamic-initializers/app/instance-initializers/browser/initializer.js
@@ -1,0 +1,2 @@
+export default `But how do you do? I see I have frightened
+you--sit down and tell me all the news.`;

--- a/tests/fixtures/dynamic-initializers/app/instance-initializers/fastboot/initializer.js
+++ b/tests/fixtures/dynamic-initializers/app/instance-initializers/fastboot/initializer.js
@@ -1,0 +1,2 @@
+export default `It was in July, 1805, and the speaker was the well-known Anna Pavlovna
+Scherer, maid of honor and favorite of the Empress Marya Fedorovna.`;


### PR DESCRIPTION
Tests for filtering out initializers and instance initializers. The rules are:

1. Initializers in `app/initializers/browser/` are not included in FastBoot builds.
2. Initializers in `app/initializers/fastboot/` are not included in browser builds
3. Initializers in `app/initializers/` are included in both.

(Similar rules apply to instance initializers.)