### PR TITLE
Use broccoli-asset-rev asset map for manifest

### DIFF
--- a/lib/addon-modes/fastboot.js
+++ b/lib/addon-modes/fastboot.js
@@ -1,10 +1,9 @@
 var path       = require('path');
 var mergeTrees = require('broccoli-merge-trees');
-var writeFile  = require('broccoli-file-creator');
 var Funnel     = require('broccoli-funnel');
 
 var filterInitializers = require('../broccoli/filter-initializers');
-var FastBootConfig     = require('../models/fastboot-config');
+var FastBootConfig     = require('../broccoli/fastboot-config');
 var fastbootAppModule  = require('../utilities/fastboot-app-module');
 
 var CONFIG = {
@@ -17,7 +16,15 @@ module.exports = {
   //
 
   included: function(app) {
+    // Save some information off from the build configuration:
+    // 1. The paths to various JavaScript and HTML files
     this.outputPaths = app.options.outputPaths;
+    // 2. The path to the asset map, if `broccoli-asset-rev` is being used
+    this.assetMapPath = app.options.assetMapPath;
+
+    // Always generate an asset map. Otherwise, we have no way of knowing where
+    // `broccoli-asset-rev` moved our stuff.
+    app.options.fingerprint.generateAssetMap = true;
   },
 
   /**
@@ -45,8 +52,17 @@ module.exports = {
    */
   postprocessTree: function(type, tree) {
     if (type === 'all') {
-      var configTree = this.treeForFastBootConfig();
-      tree = mergeTrees([tree, configTree]);
+      // Create a new Broccoli tree that writes the FastBoot app's
+      // `package.json`.
+      var config = new FastBootConfig(tree, {
+        project: this.project,
+        outputPaths: this.outputPaths,
+        assetMapPath: this.assetMapPath,
+        ui: this.ui
+      });
+
+      // Merge the package.json with the existing tree
+      return mergeTrees([config, tree]);
     }
 
     return tree;
@@ -77,19 +93,7 @@ module.exports = {
     if (type === 'app-boot') {
       return fastbootAppModule(config.modulePrefix);
     }
-  },
-
-  ///////////////////////////////
-  // METHODS
-  //
-
-  treeForFastBootConfig: function() {
-    var config = new FastBootConfig({
-      project: this.project,
-      outputPaths: this.outputPaths,
-      ui: this.ui
-    });
-    return writeFile('package.json', config.toJSONString());
   }
+
 
 };

--- a/lib/addon-modes/fastboot.js
+++ b/lib/addon-modes/fastboot.js
@@ -20,7 +20,7 @@ module.exports = {
     // 1. The paths to various JavaScript and HTML files
     this.outputPaths = app.options.outputPaths;
     // 2. The path to the asset map, if `broccoli-asset-rev` is being used
-    this.assetMapPath = app.options.assetMapPath;
+    this.assetMapPath = app.options.fingerprint.assetMapPath;
 
     // Always generate an asset map. Otherwise, we have no way of knowing where
     // `broccoli-asset-rev` moved our stuff.

--- a/lib/broccoli/fastboot-config.js
+++ b/lib/broccoli/fastboot-config.js
@@ -1,15 +1,35 @@
-var fmt = require('util').format;
-var uniq = require('lodash').uniq;
-var path = require('path');
+var fs     = require('fs');
+var fmt    = require('util').format;
+var uniq   = require('lodash').uniq;
+var path   = require('path');
+var Plugin = require('broccoli-plugin');
 
-function FastBootConfig(options) {
+function FastBootConfig(inputNode, options) {
+  Plugin.call(this, [inputNode], {
+    annotation: "Generate: FastBoot package.json"
+  });
+
   this.project = options.project;
   this.ui = options.ui;
   this.outputPaths = options.outputPaths;
+  this.assetMapPath = options.assetMapPath || 'assets/assetMap.json';
+}
 
+FastBootConfig.prototype = Object.create(Plugin.prototype);
+FastBootConfig.prototype.constructor = FastBootConfig;
+
+/**
+ * The main hook called by Broccoli Plugin. Used to build or
+ * rebuild the tree. In this case, we generate the configuration
+ * and write it to `package.json`.
+ */
+FastBootConfig.prototype.build = function() {
   this.buildDependencies();
   this.buildManifest();
-}
+
+  var outputPath = path.join(this.outputPath, 'package.json');
+  fs.writeFileSync(outputPath, this.toJSONString());
+};
 
 FastBootConfig.prototype.buildDependencies = function() {
   var dependencies = {};
@@ -42,14 +62,35 @@ FastBootConfig.prototype.buildDependencies = function() {
   this.moduleWhitelist = uniq(moduleWhitelist);
 };
 
+FastBootConfig.prototype.readAssetManifest = function() {
+  var assetMapPath = path.join(this.inputPaths[0], this.assetMapPath);
+
+  try {
+    var assetMap = JSON.parse(fs.readFileSync(assetMapPath));
+    return assetMap;
+  } catch (e) {
+    console.log(e.stack);
+  }
+};
+
 FastBootConfig.prototype.buildManifest = function() {
   var outputPaths = this.outputPaths;
 
-  this.manifest = {
+  var manifest = {
     appFile: strip(outputPaths.app.js),
     htmlFile: strip(outputPaths.app.html),
     vendorFile: strip(outputPaths.vendor.js)
   };
+
+  var rewrittenAssets = this.readAssetManifest();
+
+  if (rewrittenAssets) {
+    ['appFile', 'vendorFile'].forEach(function(file) {
+      manifest[file] = rewrittenAssets.assets[manifest[file]];
+    });
+  }
+
+  this.manifest = manifest;
 };
 
 FastBootConfig.prototype.toJSONString = function() {

--- a/lib/ext/patch-ember-app.js
+++ b/lib/ext/patch-ember-app.js
@@ -1,5 +1,3 @@
-var map = require('broccoli-stew').map;
-
 function patchEmberApp(emberApp) {
   var originalConcatFiles = emberApp.concatFiles;
 

--- a/package.json
+++ b/package.json
@@ -50,13 +50,15 @@
     "ember-addon"
   ],
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "after": [
+      "broccoli-asset-rev"
+    ]
   },
   "dependencies": {
-    "broccoli-file-creator": "^1.1.0",
     "broccoli-funnel": "0.2.8",
     "broccoli-merge-trees": "^1.1.1",
-    "broccoli-stew": "^1.2.0",
+    "broccoli-plugin": "^1.2.1",
     "chalk": "^0.5.1",
     "contextify": "^0.1.11",
     "debug": "^2.1.0",

--- a/tests/acceptance/package-json-test.js
+++ b/tests/acceptance/package-json-test.js
@@ -61,7 +61,7 @@ describe('generating package.json', function() {
 
   });
 
-  describe('production FastBoot builds', function() {
+  describe('with production FastBoot builds', function() {
 
     before(function() {
       return app.run('ember', 'fastboot:build', '--environment', 'production');
@@ -83,6 +83,34 @@ describe('generating package.json', function() {
       expect(p(manifest.htmlFile)).to.be.a.file();
       expect(p(manifest.vendorFile)).to.be.a.file();
     });
+  });
+
+  describe('with with customized fingerprinting options', function() {
+    // Tests an app with a custom `assetMapPath` set
+    var customApp = new AddonTestApp();
+
+    before(function() {
+      return customApp.create('customized-fingerprinting')
+        .then(function() {
+          return customApp.run('ember', 'fastboot:build', '--environment', 'production');
+        });
+    });
+
+    it("respects a custom asset map path and prepended URLs", function() {
+      expect(customApp.filePath('fastboot-dist/totally-customized-asset-map.json')).to.be.a.file();
+
+      var p = function(filePath) {
+        return customApp.filePath(path.join('fastboot-dist', filePath));
+      };
+
+      var pkg = fs.readJsonSync(customApp.filePath('/fastboot-dist/package.json'));
+      var manifest = pkg.fastboot.manifest;
+
+      expect(p(manifest.appFile)).to.be.a.file();
+      expect(p(manifest.htmlFile)).to.be.a.file();
+      expect(p(manifest.vendorFile)).to.be.a.file();
+    });
+
   });
 
   describe('with browser builds', function() {

--- a/tests/acceptance/package-json-test.js
+++ b/tests/acceptance/package-json-test.js
@@ -1,7 +1,8 @@
-var chai             = require('chai');
-var expect           = chai.expect;
-var fs               = require('fs-extra');
-var AddonTestApp     = require('ember-cli-addon-tests').AddonTestApp;
+var chai         = require('chai');
+var expect       = chai.expect;
+var fs           = require('fs-extra');
+var path         = require('path');
+var AddonTestApp = require('ember-cli-addon-tests').AddonTestApp;
 
 chai.use(require('chai-fs'));
 
@@ -36,7 +37,7 @@ describe('generating package.json', function() {
         "baz": "0.2.0"
       });
     });
-    
+
     it("contains a whitelist of allowed module names", function() {
       var pkg = fs.readJsonSync(app.filePath('/fastboot-dist/package.json'));
 
@@ -47,17 +48,41 @@ describe('generating package.json', function() {
         'baz'
       ]);
     });
-    
+
     it("contains a manifest of FastBoot assets", function() {
       var pkg = fs.readJsonSync(app.filePath('/fastboot-dist/package.json'));
-      
+
       expect(pkg.fastboot.manifest).to.deep.equal({
         appFile: 'assets/module-whitelist.js',
         htmlFile: 'index.html',
         vendorFile: 'assets/vendor.js'
       });
-    })
+    });
 
+  });
+
+  describe('production FastBoot builds', function() {
+
+    before(function() {
+      return app.run('ember', 'fastboot:build', '--environment', 'production');
+    });
+
+    // https://github.com/tildeio/ember-cli-fastboot/issues/102
+    // production builds have a fingerprint added to them, which was not being
+    // reflected in the manifest
+    it("contains a manifest of FastBoot assets", function() {
+      var pkg = fs.readJsonSync(app.filePath('/fastboot-dist/package.json'));
+
+      var p = function(filePath) {
+        return app.filePath(path.join('fastboot-dist', filePath));
+      };
+
+      var manifest = pkg.fastboot.manifest;
+
+      expect(p(manifest.appFile)).to.be.a.file();
+      expect(p(manifest.htmlFile)).to.be.a.file();
+      expect(p(manifest.vendorFile)).to.be.a.file();
+    });
   });
 
   describe('with browser builds', function() {

--- a/tests/fixtures/customized-fingerprinting/ember-cli-build.js
+++ b/tests/fixtures/customized-fingerprinting/ember-cli-build.js
@@ -1,0 +1,14 @@
+/*jshint node:true*/
+/* global require, module */
+var EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function(defaults) {
+  var app = new EmberApp(defaults, {
+    fingerprint: {
+      prepend: 'https://totally-sick-cdn.example.com/',
+      assetMapPath: 'totally-customized-asset-map.json'
+    }
+  });
+
+  return app.toTree();
+};


### PR DESCRIPTION
`broccoli-asset-rev` works by renaming files inside fastboot-dist so that the file name contains an MD5 hash of their contents. Unfortunately, it is hardcoded to rewrite only specific files like index.html and therefore broke the FastBoot manifest in `fastboot-dist/package.json`.

This commit modifies FastBoot to run after broccoli-asset-rev, and use a generated asset map to update the FastBoot manifest to point to the fingerprinted assets.

Fixes #102