### PR TITLE
Add a placeholder comment for generic head

### DIFF
--- a/lib/addon-modes/fastboot.js
+++ b/lib/addon-modes/fastboot.js
@@ -71,7 +71,7 @@ module.exports = {
     }
 
     if (type === 'head') {
-      return "<!-- EMBER_CLI_FASTBOOT_TITLE -->";
+      return "<!-- EMBER_CLI_FASTBOOT_TITLE --><!-- EMBER_CLI_FASTBOOT_HEAD -->";
     }
 
     if (type === 'app-boot') {


### PR DESCRIPTION
To support setting head tag content such as Facebook Open Graph tags. Can be done via [ember-cli-head](https://github.com/ronco/ember-cli-head).

This plus addon supercedes #66 .

I'd like to get some tests in here for the substitution of the placeholder by ember-fastboot-server.