### PR TITLE
Add headers to FastBoot service

### DIFF
--- a/app/services/fastboot.js
+++ b/app/services/fastboot.js
@@ -3,5 +3,6 @@ import Ember from "ember";
 let alias = Ember.computed.alias;
 
 export default Ember.Service.extend({
-  cookies: alias('_fastbootInfo.cookies')
+  cookies: alias('_fastbootInfo.cookies'),
+  headers: alias('_fastbootInfo.headers')
 });

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "broccoli-merge-trees": "^1.1.1",
     "broccoli-plugin": "^1.2.1",
     "contextify": "^0.1.11",
-    "ember-fastboot-server": "0.5.0",
+    "ember-fastboot-server": "0.5.1",
     "express": "^4.8.5",
     "lodash": "^3.1.0",
     "rsvp": "^3.0.16"

--- a/tests/acceptance/headers-test.js
+++ b/tests/acceptance/headers-test.js
@@ -1,0 +1,40 @@
+var chai = require('chai');
+var expect = chai.expect;
+var RSVP = require('rsvp');
+var AddonTestApp = require('ember-cli-addon-tests').AddonTestApp;
+var request = require('request');
+var get = RSVP.denodeify(request);
+
+describe('headers', function() {
+  this.timeout(300000);
+
+  var app;
+
+  before(function() {
+
+    app = new AddonTestApp();
+
+    return app.create('headers')
+      .then(function() {
+        return app.startServer({
+          command: 'fastboot',
+          additionalArguments: ['--serve-assets']
+        });
+      });
+  });
+
+  after(function() {
+    return app.stopServer();
+  });
+
+  it('makes headers available via a service', function() {
+    return get({
+      url: 'http://localhost:49741/list-headers',
+      headers: { 'X-FastBoot-info': 'foobar' }
+    })
+      .then(function(response) {
+        expect(response.body).to.contain('Headers: foobar');
+        expect(response.body).to.contain('Headers from Instance Initializer: foobar');
+      });
+  });
+});

--- a/tests/fixtures/headers/app/controllers/list-headers.js
+++ b/tests/fixtures/headers/app/controllers/list-headers.js
@@ -1,0 +1,4 @@
+import Ember from "ember";
+
+export default Ember.Controller.extend({
+});

--- a/tests/fixtures/headers/app/instance-initializers/list-headers.js
+++ b/tests/fixtures/headers/app/instance-initializers/list-headers.js
@@ -1,0 +1,9 @@
+export default {
+  name: 'test-headers',
+  initialize(applicationInstance) {
+    let listCookiesController = applicationInstance.lookup('controller:list-headers');
+    let fastbootInfo = applicationInstance.lookup('info:-fastboot');
+
+    listCookiesController.set('instanceInitializerHeader', fastbootInfo.headers['x-fastboot-info']);
+  }
+};

--- a/tests/fixtures/headers/app/router.js
+++ b/tests/fixtures/headers/app/router.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import config from './config/environment';
+
+var Router = Ember.Router.extend({
+  location: config.locationType
+});
+
+Router.map(function() {
+  this.route('list-headers');
+});
+
+export default Router;

--- a/tests/fixtures/headers/app/routes/list-headers.js
+++ b/tests/fixtures/headers/app/routes/list-headers.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  fastboot: Ember.inject.service(),
+
+  model() {
+    return {
+      headers: this.get('fastboot.headers')
+    };
+  }
+});

--- a/tests/fixtures/headers/app/templates/list-headers.hbs
+++ b/tests/fixtures/headers/app/templates/list-headers.hbs
@@ -1,0 +1,2 @@
+Headers: {{model.headers.x-fastboot-info}}
+Headers from Instance Initializer: {{instanceInitializerHeader}}


### PR DESCRIPTION
This is #123 with the ember-fastboot-server dependency bumped