### PR TITLE
Unify build tasks

### DIFF
--- a/lib/commands/fastboot-build.js
+++ b/lib/commands/fastboot-build.js
@@ -10,9 +10,7 @@ module.exports = {
   ],
 
   run: function(options, args) {
-    process.env.EMBER_CLI_FASTBOOT = true;
-
-    var BuildTask = this.tasks.Build;
+    var BuildTask = require('../tasks/fastboot-build');
     var buildTask = new BuildTask({
       ui: this.ui,
       analytics: this.analytics,

--- a/lib/commands/fastboot.js
+++ b/lib/commands/fastboot.js
@@ -59,7 +59,7 @@ module.exports = {
   },
 
   triggerBuild: function(commandOptions) {
-    var BuildTask = this.tasks.Build;
+    var BuildTask = require('../tasks/fastboot-build');
     var buildTask = new BuildTask({
       ui: this.ui,
       analytics: this.analytics,
@@ -70,8 +70,6 @@ module.exports = {
   },
 
   run: function(options, args) {
-    process.env.EMBER_CLI_FASTBOOT = true;
-
     this.commandOptions = options;
 
     var runCommand = function() {

--- a/lib/tasks/fastboot-build.js
+++ b/lib/tasks/fastboot-build.js
@@ -1,0 +1,12 @@
+var BuildTask = require('ember-cli/lib/tasks/build');
+
+module.exports = BuildTask.extend({
+  run: function(options) {
+    process.env.EMBER_CLI_FASTBOOT = true;
+
+    return this._super.run.apply(this, arguments)
+      .finally(function() {
+        delete process.env.EMBER_CLI_FASTBOOT;
+      });
+  }
+});


### PR DESCRIPTION
This creats a single FastBoot build task that encapsulates the differences from a regular build. This also properly cleans up the EMBER_CLI_FASTBOOT env once the build finishes.