### PR TITLE
Add host whitelist from environment.js

### DIFF
--- a/lib/addon-modes/fastboot.js
+++ b/lib/addon-modes/fastboot.js
@@ -49,13 +49,16 @@ module.exports = {
    */
   postprocessTree: function(type, tree) {
     if (type === 'all') {
+      var environment = process.env['EMBER_ENV'] || 'development';
+
       // Create a new Broccoli tree that writes the FastBoot app's
       // `package.json`.
       var config = new FastBootConfig(tree, {
         project: this.project,
         outputPaths: this.outputPaths,
         assetMapPath: this.assetMapPath,
-        ui: this.ui
+        ui: this.ui,
+        fastbootAppConfig: this.project.config(environment).fastboot
       });
 
       // Merge the package.json with the existing tree

--- a/lib/broccoli/fastboot-config.js
+++ b/lib/broccoli/fastboot-config.js
@@ -13,6 +13,7 @@ function FastBootConfig(inputNode, options) {
   this.ui = options.ui;
   this.outputPaths = options.outputPaths;
   this.assetMapPath = options.assetMapPath || 'assets/assetMap.json';
+  this.fastbootAppConfig = options.fastbootAppConfig;
 }
 
 FastBootConfig.prototype = Object.create(Plugin.prototype);
@@ -26,6 +27,7 @@ FastBootConfig.prototype.constructor = FastBootConfig;
 FastBootConfig.prototype.build = function() {
   this.buildDependencies();
   this.buildManifest();
+  this.buildHostWhitelist();
 
   var outputPath = path.join(this.outputPath, 'package.json');
   fs.writeFileSync(outputPath, this.toJSONString());
@@ -107,15 +109,37 @@ FastBootConfig.prototype.buildManifest = function() {
   this.manifest = manifest;
 };
 
+FastBootConfig.prototype.buildHostWhitelist = function() {
+  if (!!this.fastbootAppConfig) {
+    this.hostWhitelist = this.fastbootAppConfig.hostWhitelist;
+  }
+};
+
 FastBootConfig.prototype.toJSONString = function() {
   return JSON.stringify({
     dependencies: this.dependencies,
     fastboot: {
       moduleWhitelist: this.moduleWhitelist,
-      manifest: this.manifest
+      manifest: this.manifest,
+      hostWhitelist: this.normalizeHostWhitelist()
     }
   }, null, 2);
 };
+
+FastBootConfig.prototype.normalizeHostWhitelist = function() {
+  if (!this.hostWhitelist) {
+    return;
+  }
+
+  return this.hostWhitelist.map(function(entry) {
+    // Is a regex
+    if (entry.source) {
+      return '/' + entry.source + '/';
+    } else {
+      return entry;
+    }
+  });
+}
 
 function eachAddonPackage(project, cb) {
   project.addons.map(function(addon) {

--- a/tests/acceptance/package-json-test.js
+++ b/tests/acceptance/package-json-test.js
@@ -64,6 +64,16 @@ describe('generating package.json', function() {
       });
     });
 
+    it("contains a list of whitelisted hosts from environment.js", function() {
+      var pkg = fs.readJsonSync(app.filePath('/fastboot-dist/package.json'));
+
+      expect(pkg.fastboot.hostWhitelist).to.deep.equal([
+        'example.com',
+        'subdomain.example.com',
+        '/localhost:\\d+/'
+      ]);
+    });
+
   });
 
   describe('with production FastBoot builds', function() {

--- a/tests/fixtures/module-whitelist/config/environment.js
+++ b/tests/fixtures/module-whitelist/config/environment.js
@@ -1,0 +1,51 @@
+/* jshint node: true */
+
+module.exports = function(environment) {
+  var ENV = {
+    modulePrefix: 'module-whitelist',
+    environment: environment,
+    baseURL: '/',
+    locationType: 'auto',
+    EmberENV: {
+      FEATURES: {
+        // Here you can enable experimental features on an ember canary build
+        // e.g. 'with-controller': true
+      }
+    },
+
+    APP: {
+      // Here you can pass flags/options to your application instance
+      // when it is created
+    },
+
+    fastboot: {
+      hostWhitelist: ['example.com', 'subdomain.example.com', /localhost:\d+/]
+    }
+  };
+
+  if (environment === 'development') {
+    // ENV.APP.LOG_RESOLVER = true;
+    // ENV.APP.LOG_ACTIVE_GENERATION = true;
+    // ENV.APP.LOG_TRANSITIONS = true;
+    // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
+    // ENV.APP.LOG_VIEW_LOOKUPS = true;
+  }
+
+  if (environment === 'test') {
+    // Testem prefers this...
+    ENV.baseURL = '/';
+    ENV.locationType = 'none';
+
+    // keep test console output quieter
+    ENV.APP.LOG_ACTIVE_GENERATION = false;
+    ENV.APP.LOG_VIEW_LOOKUPS = false;
+
+    ENV.APP.rootElement = '#ember-testing';
+  }
+
+  if (environment === 'production') {
+
+  }
+
+  return ENV;
+};


### PR DESCRIPTION
Handles regex by turning it into a string in the `package.json`, ember-fastboot-server will handle this correctly