### PR TITLE
Introduce API for current host

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,59 @@ export default Ember.Route.extend({
 The service's `cookies` property is an object containing the request's
 cookies as key/value pairs.
 
+### Host
+
+You can access the host of the request that the current FastBoot server
+is responding to via the `fastboot` service. The `host` function will
+return the protocol and the host (`https://example.com`).
+
+```js
+export default Ember.Route.extend({
+  fastboot: Ember.inject.service(),
+
+  model() {
+    let host = this.get('fastboot').host();
+    // ...
+  }
+});
+```
+
+To retrieve the host of the current request, you must specify a list of
+hosts that you expect in your `config/environment.js`:
+
+```js
+module.exports = function(environment) {
+  var ENV = {
+    modulePrefix: 'host',
+    environment: environment,
+    baseURL: '/',
+    locationType: 'auto',
+    EmberENV: {
+      // ...
+    },
+    APP: {
+      // ...
+    },
+
+    fastboot: {
+      hostWhitelist: ['example.com', 'subdomain.example.com', /^localhost:\d+$/]
+    }
+  };
+  // ...
+};
+```
+
+The `hostWhitelist` can be a string or RegExp to match multiple hosts.
+Care should be taken when using a RegExp, as the host function relies on
+the `Host` HTTP header, which can be forged. You could potentially allow
+a malicious request if your RegExp is too permissive when using the `host`
+when making subsequent requests.
+
+Retrieving `host` will error on 2 conditions:
+
+ 1. you do not have a `hostWhitelist` defined
+ 2. the `Host` header does not match an entry in your `hostWhitelist`
+
 ## Known Limitations
 
 While FastBoot is under active development, there are several major

--- a/app/services/fastboot.js
+++ b/app/services/fastboot.js
@@ -1,8 +1,12 @@
 import Ember from "ember";
 
 let alias = Ember.computed.alias;
+let computed = Ember.computed;
 
 export default Ember.Service.extend({
   cookies: alias('_fastbootInfo.cookies'),
-  headers: alias('_fastbootInfo.headers')
+  headers: alias('_fastbootInfo.headers'),
+  host: computed(function() {
+    return this._fastbootInfo.host();
+  })
 });

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "broccoli-merge-trees": "^1.1.1",
     "broccoli-plugin": "^1.2.1",
     "contextify": "^0.1.11",
-    "ember-fastboot-server": "0.5.1",
+    "ember-fastboot-server": "0.5.3",
     "express": "^4.8.5",
     "lodash": "^3.1.0",
     "rsvp": "^3.0.16"

--- a/tests/acceptance/host-test.js
+++ b/tests/acceptance/host-test.js
@@ -1,0 +1,39 @@
+var chai = require('chai');
+var expect = chai.expect;
+var RSVP = require('rsvp');
+var AddonTestApp = require('ember-cli-addon-tests').AddonTestApp;
+var request = require('request');
+var get = RSVP.denodeify(request);
+
+describe('host', function() {
+  this.timeout(300000);
+
+  var app;
+
+  before(function() {
+
+    app = new AddonTestApp();
+
+    return app.create('host')
+      .then(function() {
+        return app.startServer({
+          command: 'fastboot',
+          additionalArguments: ['--serve-assets']
+        });
+      });
+  });
+
+  after(function() {
+    return app.stopServer();
+  });
+
+  it('makes host available via a service', function() {
+    return get({
+      url: 'http://localhost:49741/show-host'
+    })
+      .then(function(response) {
+        expect(response.body).to.contain('Host: http://localhost:49741');
+        expect(response.body).to.contain('Host from Instance Initializer: http://localhost:49741');
+      });
+  });
+});

--- a/tests/fixtures/host/app/controllers/show-host.js
+++ b/tests/fixtures/host/app/controllers/show-host.js
@@ -1,0 +1,4 @@
+import Ember from "ember";
+
+export default Ember.Controller.extend({
+});

--- a/tests/fixtures/host/app/instance-initializers/show-host.js
+++ b/tests/fixtures/host/app/instance-initializers/show-host.js
@@ -1,0 +1,9 @@
+export default {
+  name: 'test-host',
+  initialize(applicationInstance) {
+    let showHostController = applicationInstance.lookup('controller:show-host');
+    let fastbootInfo = applicationInstance.lookup('info:-fastboot');
+
+    showHostController.set('instanceInitializerHost', fastbootInfo.host());
+  }
+};

--- a/tests/fixtures/host/app/router.js
+++ b/tests/fixtures/host/app/router.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import config from './config/environment';
+
+var Router = Ember.Router.extend({
+  location: config.locationType
+});
+
+Router.map(function() {
+  this.route('show-host');
+});
+
+export default Router;

--- a/tests/fixtures/host/app/routes/show-host.js
+++ b/tests/fixtures/host/app/routes/show-host.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  fastboot: Ember.inject.service(),
+
+  model() {
+    return {
+      host: this.get('fastboot.host')
+    };
+  }
+});

--- a/tests/fixtures/host/app/templates/show-host.hbs
+++ b/tests/fixtures/host/app/templates/show-host.hbs
@@ -1,0 +1,2 @@
+Host: {{model.host}}
+Host from Instance Initializer: {{instanceInitializerHost}}

--- a/tests/fixtures/host/config/environment.js
+++ b/tests/fixtures/host/config/environment.js
@@ -1,0 +1,51 @@
+/* jshint node: true */
+
+module.exports = function(environment) {
+  var ENV = {
+    modulePrefix: 'host',
+    environment: environment,
+    baseURL: '/',
+    locationType: 'auto',
+    EmberENV: {
+      FEATURES: {
+        // Here you can enable experimental features on an ember canary build
+        // e.g. 'with-controller': true
+      }
+    },
+
+    APP: {
+      // Here you can pass flags/options to your application instance
+      // when it is created
+    },
+
+    fastboot: {
+      hostWhitelist: ['example.com', 'subdomain.example.com', /localhost:\d+/]
+    }
+  };
+
+  if (environment === 'development') {
+    // ENV.APP.LOG_RESOLVER = true;
+    // ENV.APP.LOG_ACTIVE_GENERATION = true;
+    // ENV.APP.LOG_TRANSITIONS = true;
+    // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
+    // ENV.APP.LOG_VIEW_LOOKUPS = true;
+  }
+
+  if (environment === 'test') {
+    // Testem prefers this...
+    ENV.baseURL = '/';
+    ENV.locationType = 'none';
+
+    // keep test console output quieter
+    ENV.APP.LOG_ACTIVE_GENERATION = false;
+    ENV.APP.LOG_VIEW_LOOKUPS = false;
+
+    ENV.APP.rootElement = '#ember-testing';
+  }
+
+  if (environment === 'production') {
+
+  }
+
+  return ENV;
+};


### PR DESCRIPTION
This makes the host of the current request available from within the
fastboot service

This should be merged after ~~https://github.com/ember-fastboot/ember-fastboot-server/pull/29~~ and #131