### PR TITLE
[bugfix] work around duplicated babel plugin options

### DIFF
--- a/lib/broccoli/fastboot-build.js
+++ b/lib/broccoli/fastboot-build.js
@@ -57,6 +57,16 @@ FastBootBuild.prototype.appOptions = function() {
   options.autoRun = false;
   options.project = this.buildFastBootProject();
 
+  // If plugins get included twice, babel complains about duplicate
+  // plugins with the same name and will throw an error that
+  // causes the build to fail.
+  // We can remove them here and they should hopefully be picked up
+  // by `new EmberApp()`. I don't know if this excludes plugins that
+  // are included by putting babel options in `ember-cli-build.js`.
+  if (options.babel && options.babel.plugins) {
+    delete options.babel.plugins;
+  }
+
   return options;
 };
 


### PR DESCRIPTION
When another addon, like Ember Data, uses a babel plugin to change code
at build time, babel (provided by ember-cli-babel) throws an exception
that the plugin cannot be included twice because it has the same name.
This is happening because copying `plugins` of the original app's
`options` includes addon's babel plugins. Passing those options to `new
EmberApp()` causes the plugins to get loaded twice by `EmberApp`'s
loading logic.

I don't know what the right solution is. Maybe ember-cli-babel should
de-dupe options. Maybe we need some way to get at the `options` hash
that was present before the `EmberApp`'s initializers were run.