### PR TITLE
Automatically adds /fastboot-dist to project .gitignore

### DIFF
--- a/blueprints/ember-cli-fastboot/index.js
+++ b/blueprints/ember-cli-fastboot/index.js
@@ -1,0 +1,17 @@
+/*jshint node:true*/
+
+'use strict';
+
+module.exports = {
+  normalizeEntityName: function() {
+    // this prevents an error when the entityName is
+    // not specified (since that doesn't actually matter
+    // to us
+  },
+
+  afterInstall: function() {
+    return this.insertIntoFile('.gitignore', '\n/fastboot-dist', {
+      after: '/dist'
+    });
+  }
+};


### PR DESCRIPTION
Doesn't need much explaining, just adds `/fastboot-dist` to `.gitignore` when ember-cli-fastboot is installed.